### PR TITLE
Add ability to create donation requests in campaign builder

### DIFF
--- a/components/CampaignBuilder/Donations/RequestDonation.js
+++ b/components/CampaignBuilder/Donations/RequestDonation.js
@@ -1,17 +1,71 @@
 import React, { Component } from 'react';
-import { View, Text } from 'react-native';
+import { View, Text, Alert } from 'react-native';
 import styles from '../../../constants/CampaignBuilder/Donations/RequestDonation';
+import { TextInput, TouchableOpacity } from 'react-native-gesture-handler';
+import PlusSign from '../../../assets/jsicons/headerIcons/plusSign';
+import CrossCircle from '../../../assets/jsicons/CrossCircle';
 
 export default class RequestDonation extends Component {
   constructor(props) {
     super(props);
-    this.state = {};
+    this.state = {
+      goals: [
+        {
+          title: 'New goal...',
+          goal: 500,
+        },
+      ],
+    };
   }
+
+  addGoal = () => {
+    this.setState(
+      (prevState) => ({
+        goals: [
+          ...prevState.goals,
+          {
+            title: 'New Goal',
+            goal: 20,
+          },
+        ],
+      }),
+      () => this.props.onChange?.(this.state.goals)
+    );
+  };
+
+  removeGoal = (index) => {
+    this.setState(
+      (prevState) => {
+        const newGoals = Array.from(prevState.goals);
+
+        newGoals.splice(index, 1);
+        return {
+          goals: newGoals,
+        };
+      },
+      () => this.props.onChange?.(this.state.goals)
+    );
+  };
+
+  editGoal = (index, goal) => {
+    this.setState(
+      (prevState) => {
+        const newGoals = Array.from(prevState.goals);
+
+        newGoals[index] = goal;
+
+        return {
+          goals: newGoals,
+        };
+      },
+      () => this.props.onChange?.(this.state.goals)
+    );
+  };
 
   render() {
     return (
-      <View style={styles.itemContainers}>
-        <Text>
+      <View style={styles.container}>
+        <Text style={styles.description}>
           In an effort to remain transparent and help supporters know where
           their money is going, we offer organizations the option to list
           multiple, more specific goals rather than a bigger, more obscure one.
@@ -19,7 +73,85 @@ export default class RequestDonation extends Component {
           list, but you may always create one goal if this does not apply to
           you.
         </Text>
+        <Text style={styles.subheader}>Goals</Text>
+        <View style={styles.goals}>
+          {this.state.goals.length > 0 ? (
+            this.state.goals.map((goal, index) => {
+              return (
+                <DonationGoal
+                  key={index}
+                  title={goal.title}
+                  goal={goal.goal}
+                  onTitleChange={(title) =>
+                    this.editGoal(index, {
+                      ...goal,
+                      title,
+                    })
+                  }
+                  onGoalChange={(goalAmount) =>
+                    this.editGoal(index, {
+                      ...goal,
+                      goal: Number(goalAmount),
+                    })
+                  }
+                  onDeleteGoal={() => this.removeGoal(index)}
+                />
+              );
+            })
+          ) : (
+            <View style={styles.noGoalsContainer}>
+              <Text style={styles.noGoalsText}>
+                Tap 'Add another goal' below to get started
+              </Text>
+            </View>
+          )}
+        </View>
+        <TouchableOpacity onPress={this.addGoal} style={styles.addButton}>
+          <View style={styles.plusSign}>
+            <PlusSign />
+          </View>
+          <Text style={styles.addButtonText}>Add another goal</Text>
+        </TouchableOpacity>
       </View>
     );
   }
 }
+
+const DonationGoal = (props) => {
+  const promptDeleteGoal = () => {
+    Alert.alert('Delete goal', 'Are you sure you want to delete this goal?', [
+      {
+        onPress: props.onDeleteGoal,
+        style: 'destructive',
+        text: 'Delete Goal',
+      },
+      { style: 'cancel', text: 'Cancel' },
+    ]);
+  };
+
+  return (
+    <View style={styles.donationGoal}>
+      <TouchableOpacity onPress={promptDeleteGoal}>
+        <CrossCircle width={24} height={24} marginRight={8} marginTop={8} />
+      </TouchableOpacity>
+      <View style={styles.inputs}>
+        <TextInput
+          style={styles.textInput}
+          placeholder="New goal..."
+          value={props.title}
+          onChangeText={props.onTitleChange}
+        />
+        <View style={styles.field}>
+          <Text style={styles.fieldLabel}>Goal amount:{`   `}$ </Text>
+          <TextInput
+            style={styles.textInput}
+            placeholder="250"
+            value={props.goal.toString()}
+            keyboardType="number-pad"
+            onChangeText={props.onGoalChange}
+          />
+        </View>
+      </View>
+    </View>
+  );
+};

--- a/constants/CampaignBuilder/Donations/RequestDonation.js
+++ b/constants/CampaignBuilder/Donations/RequestDonation.js
@@ -1,41 +1,81 @@
 import { StyleSheet } from 'react-native';
 
 export default StyleSheet.create({
-  itemContainers: {
-    flexDirection: 'column',
+  container: {
+    flex: 1,
     padding: 12,
-    backgroundColor: 'white',
-    borderRadius: 8,
+  },
+  description: {
+    marginBottom: 16,
+  },
+  subheader: {
+    fontSize: 18,
+    fontFamily: 'Lato-Bold',
     marginBottom: 8,
   },
-  itemTitleRow: {
-    width: '100%',
-    flexDirection: 'row',
-    flexWrap: 'wrap',
-    alignContent: 'stretch',
-    paddingLeft: 5,
-    paddingRight: 15,
-    paddingTop: 10,
-    paddingBottom: 10,
+  goals: {
+    flex: 1,
+    flexDirection: 'column',
   },
-  itemTitleText: {
-    fontSize: 17,
-    marginLeft: 7,
-    textAlign: 'left',
-    fontFamily: 'Lato-Bold',
+  textInput: {
+    flex: 1,
+    height: 34,
+    backgroundColor: '#F5F5F5',
+    padding: 8,
+    borderRadius: 5,
+    fontSize: 16,
+    marginTop: 4,
+    textAlignVertical: 'top',
+  },
+  bullet: {
+    width: 20,
+    height: 20,
+    marginRight: 8,
+    marginTop: 8,
+    borderRadius: 50,
+    backgroundColor: '#00FF9D',
+  },
+  donationGoal: {
+    flexDirection: 'row',
+  },
+  plusSign: {
     alignSelf: 'center',
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginTop: 5,
+    marginRight: 8,
+    width: 30,
+    height: 30,
+    borderWidth: 2,
+    borderRadius: 15,
   },
-  switchContainer: {
-    marginLeft: 'auto',
-  },
-  itemContentBody: {
-    width: '100%',
+  addButton: {
+    marginTop: 16,
     flexDirection: 'row',
-    flexWrap: 'wrap',
-    alignContent: 'stretch',
-    paddingLeft: 5,
-    paddingRight: 5,
-    paddingTop: 10,
-    paddingBottom: 5,
+    alignItems: 'center',
+  },
+  addButtonText: {
+    fontFamily: 'Lato-Bold',
+    fontSize: 15,
+  },
+  inputs: {
+    flex: 1,
+    flexDirection: 'column',
+  },
+  field: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  fieldLabel: {
+    fontFamily: 'Lato-Bold',
+  },
+  noGoalsContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    paddingVertical: 8,
+  },
+  noGoalsText: {
+    color: 'gray',
   },
 });

--- a/screens/AccountSettingsScreen.js
+++ b/screens/AccountSettingsScreen.js
@@ -8,6 +8,8 @@ import { logout } from '../store/actions';
 import LogoutSymbol from '../assets/jsicons/accountSettings/LogoutSymbol';
 import styles from '../constants/screens/AccountSettingsScreen';
 import DoneButton from '../components/DoneButton';
+import CreditCard from '../assets/jsicons/CreditCard';
+import Cabinet from '../assets/jsicons/Cabinet';
 
 class AccountSettingsScreen extends React.Component {
   state = {
@@ -70,18 +72,18 @@ class AccountSettingsScreen extends React.Component {
               onPress={this.viewReports}
             >
               <View style={styles.logoutButton}>
-                <LogoutSymbol />
+                <Cabinet />
               </View>
               <Text style={styles.linkText}>Manage Reports</Text>
             </TouchableOpacity>
           </View>
         )}
         <View style={styles.sections}>
-          {this.state.roles === 'conservationist' && (
+          {this.props.currentUserProfile.roles === 'conservationist' && (
             <>
               <TouchableOpacity style={styles.linkWrap} onPress={this.payments}>
                 <View style={styles.logoutButton}>
-                  <LogoutSymbol />
+                  <CreditCard />
                 </View>
                 <Text style={styles.linkText}>Payments</Text>
               </TouchableOpacity>

--- a/screens/CreateCampaignScreen.js
+++ b/screens/CreateCampaignScreen.js
@@ -80,7 +80,7 @@ class CreateCampaignScreen extends React.Component {
     skillImpactRequests: new Map(),
     urgency: null,
     donationsEnabled: false,
-    donationRequests: {},
+    donationRequests: [],
   };
 
   setUrgency = (urgencyLevel) => {
@@ -93,22 +93,6 @@ class CreateCampaignScreen extends React.Component {
         urgency: urgencyLevel,
       });
     }
-  };
-
-  enableDonations = () => {
-    this.setState({ donationsEnabled: true });
-  };
-
-  disableDonations = () => {
-    this.setState({ donationsEnabled: false });
-  };
-
-  enableSkilledImpact = () => {
-    this.setState({ skilledImpactEnabled: true });
-  };
-
-  enableSkilledImpact = () => {
-    this.setState({ skilledImpactEnabled: false });
   };
 
   isProjectGoalArrValid = (projectGoalArr) => {
@@ -138,27 +122,38 @@ class CreateCampaignScreen extends React.Component {
     }
   };
 
+  isDonationRequestValid = () => {
+    return this.state.donationRequests.every((request) => {
+      return request.title?.trim() && request.goal > 0;
+    });
+  };
+
   publish = () => {
     const skilledImpactValid =
       !this.state.skilledImpactEnabled ||
       !this.isSkillImpactRequestValid(this.state.skillImpactRequests);
+
+    const donationsValid =
+      !this.state.donationsEnabled || !this.isDonationRequestValid();
 
     if (
       !this.state.image ||
       !this.state.name ||
       !this.state.description ||
       skilledImpactValid ||
+      donationsValid ||
       !this.state.urgency
     ) {
       const errorMessage =
-        'Form incomplete. Please include:' +
+        'Form invalid or incomplete. Please check the following:' +
         (this.state.image ? '' : '\n    - Campaign Image') +
         (this.state.name ? '' : '\n    - Campaign Name') +
         (this.state.description ? '' : '\n    - Campaign Details') +
         (this.isSkillImpactRequestValid(this.state.skillImpactRequests)
           ? ''
           : '\n    - Skill Impact Requests Form') +
-        (this.state.urgency ? '' : '    - Urgency Level\n ');
+        (this.isDonationRequestValid() ? '' : '\n    - Donations') +
+        (this.state.urgency ? '' : '\n    - Urgency Level\n ');
       return Alert.alert('Error', errorMessage);
     } else {
       const campaign = {
@@ -296,16 +291,20 @@ class CreateCampaignScreen extends React.Component {
         <OptionalSection
           title="Donations"
           icon={CreditCard}
-          onCollapse={this.disableDonations}
-          onExpand={this.enableDonations}
+          onCollapse={() => this.setState({ donationsEnabled: false })}
+          onExpand={() => this.setState({ donationsEnabled: true })}
         >
-          <RequestDonation />
+          <RequestDonation
+            onChange={(requests) =>
+              this.setState({ donationRequests: requests })
+            }
+          />
         </OptionalSection>
         <OptionalSection
           title="Skilled Impact"
           icon={Sync}
-          onCollapse={this.disableSkilledImpact}
-          onExpand={this.enableSkilledImpact}
+          onCollapse={() => this.setState({ skilledImpactEnabled: false })}
+          onExpand={() => this.setState({ skilledImpactEnabled: true })}
         >
           <SelectSkillsContent
             skillImpactRequests={this.state.skillImpactRequests}


### PR DESCRIPTION
This adds the all the functionality necessary to create donation requests in the CampaignBuilder

TODO:
- Implement functionality to interpret new donation requests in the POST /campaigns endpoint on the backend, the same place skilled impact requests are also processed
- Rebuild and optimize take action UI
- Add donation UI to take action screens
- Build/link to donate screen on either web front-end or PayPal